### PR TITLE
Expose parsing of operators to API

### DIFF
--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -107,8 +107,8 @@ struct rpnBuilder {
 
 // The reservedWordParser_t is the function type called when
 // a reserved word is found at parsing time.
-typedef TokenBase* rWordParser_t(const char* expr, const char** rest,
-                                 rpnBuilder* data);
+typedef void rWordParser_t(const char* expr, const char** rest,
+                           rpnBuilder* data);
 typedef std::map<std::string, rWordParser_t*> rWordMap_t;
 
 struct RefToken : public TokenBase {

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -551,6 +551,7 @@ TEST_CASE("Parsing as slave parser") {
   REQUIRE_THROWS(calculator::calculate(error_test, vars, "\n;", &code));
 }
 
+// This function is for internal use only:
 TEST_CASE("operation_id() function", "[op_id]") {
   #define opID(t1, t2) Operation::build_mask(t1, t2)
   REQUIRE((opID(NONE, NONE)) == 0x0000000100000001);
@@ -627,6 +628,18 @@ TEST_CASE("Resource management") {
   REQUIRE_NOTHROW(calculator C3(C2));
   // Assignment:
   REQUIRE_NOTHROW(C1 = C2);
+}
+
+/* * * * * Testing adhoc operator parser * * * * */
+
+TEST_CASE("Adhoc operator parser", "[operator]") {
+  // Testing comments:
+  REQUIRE(calculator::calculate("1 + 1 # And a comment!").asInt() == 2);
+  REQUIRE(calculator::calculate("1 + 1 /*And a comment!*/").asInt() == 2);
+  REQUIRE(calculator::calculate("1 /* + 1 */").asInt() == 1);
+  REQUIRE(calculator::calculate("1 /* in-between */ + 1").asInt() == 2);
+
+  REQUIRE_THROWS(calculator::calculate("1 + 1 /* Never ending comment"));
 }
 
 TEST_CASE("Exception management") {


### PR DESCRIPTION
Now you can define how you want an operator
to be parsed just like you do with a reserved word:

```C++
void LineComment(const char* expr, const char** rest, rpnBuilder* data) {
  while (*expr && *expr != '\n') ++expr;
  if (*expr != '\0') ++expr;
  *rest = expr;
}

class Startup {
  Startup() {
    rWordMap_t& rwMap = calculator::default_rWordMap();
    rwMap["#"] = &LineComment;
    rwMap["//"] = &LineComment;
  }
};
```

This commit also changes the return type of these reserved word
parser functions. Before they would return a TokenBase* type,
now they return void.

The reasoning is that if you want to add a new token, you already
have access to the `data->rpn` queue, so why add 2 different ways
to do the same thing? Also when parsing a comment for example
there is no sense in returning any value.

So now if you want to add something to the rpn queue it must
be done inside the sub-parser function.