### PR TITLE
Op Associativity API + Minor fixes, refactors and updates

### DIFF
--- a/builtin-features.cpp
+++ b/builtin-features.cpp
@@ -284,17 +284,17 @@ struct Startup {
     // precedence order as described on cppreference website:
     // http://en.cppreference.com/w/cpp/language/operator_precedence
     OppMap_t& opp = calculator::default_opPrecedence();
-    opp["[]"] = 2; opp["()"] = 2; opp["."] = 2;
-    opp["**"] = 3;
-    opp["*"]  = 5; opp["/"]  = 5; opp["%"] = 5;
-    opp["+"]  = 6; opp["-"]  = 6;
-    opp["<<"] = 7; opp[">>"] = 7;
-    opp["<"]  = 8; opp["<="] = 8; opp[">="] = 8; opp[">"] = 8;
-    opp["=="] = 9; opp["!="] = 9;
-    opp["&&"] = 13;
-    opp["||"] = 14;
-    opp["="]  = 15; opp[":"] = 15;
-    opp[","]  = 16;
+    opp.add("[]", 2); opp.add("()", 2); opp.add(".", 2);
+    opp.add("**", 3);
+    opp.add("*",  5); opp.add("/", 5); opp.add("%", 5);
+    opp.add("+",  6); opp.add("-", 6);
+    opp.add("<<", 7); opp.add(">>", 7);
+    opp.add("<",  8); opp.add("<=", 8); opp.add(">=", 8); opp.add(">", 8);
+    opp.add("==", 9); opp.add("!=", 9);
+    opp.add("&&", 13);
+    opp.add("||", 14);
+    opp.add("=", 15); opp.add(":", 15);
+    opp.add(",", 16);
 
     // Link operations to respective operators:
     opMap_t& opMap = calculator::default_opMap();

--- a/builtin-features.cpp
+++ b/builtin-features.cpp
@@ -327,15 +327,15 @@ packToken falseToken = packToken(0);
 packToken noneToken = packToken::None;
 
 void True(const char* expr, const char** rest, rpnBuilder* data) {
-  data->rpn.push(trueToken->clone());
+  data->handle_token(trueToken->clone());
 }
 
 void False(const char* expr, const char** rest, rpnBuilder* data) {
-  data->rpn.push(falseToken->clone());
+  data->handle_token(falseToken->clone());
 }
 
 void None(const char* expr, const char** rest, rpnBuilder* data) {
-  data->rpn.push(noneToken->clone());
+  data->handle_token(noneToken->clone());
 }
 
 void LineComment(const char* expr, const char** rest, rpnBuilder* data) {

--- a/objects.h
+++ b/objects.h
@@ -144,7 +144,12 @@ class TokenList : public pack<TokenList_t>, public Iterable {
   TokenList() { this->type = LIST; }
   virtual ~TokenList() {}
 
-  packToken& operator[](const uint64_t idx) { return list()[idx]; }
+  packToken& operator[](const uint64_t idx) {
+    if (list().size() <= idx || idx < 0) {
+      throw std::out_of_range("List index out of range!");
+    }
+    return list()[idx];
+  }
 
  public:
   // Implement the TokenBase abstract class

--- a/objects.h
+++ b/objects.h
@@ -144,11 +144,18 @@ class TokenList : public pack<TokenList_t>, public Iterable {
   TokenList() { this->type = LIST; }
   virtual ~TokenList() {}
 
-  packToken& operator[](const uint64_t idx) {
+  packToken& operator[](const uint64_t idx) const {
     if (list().size() <= idx || idx < 0) {
       throw std::out_of_range("List index out of range!");
     }
     return list()[idx];
+  }
+
+  void push(packToken val) const { list().push_back(val); }
+  packToken pop() const {
+    packToken back = list().back();
+    list().pop_back();
+    return back;
   }
 
  public:

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -152,7 +152,7 @@ void rpnBuilder::handle_op(const std::string& op) {
   //     pop o2 off the stack onto the output queue.
   //   Push o1 on the stack.
 
-  // If it is associates left to right:
+  // If it associates from left to right:
   if (opp.assoc(op) == 0) {
     while (!opStack.empty() && opp.prec(op) >= opp.prec(opStack.top())) {
       rpn.push(new Token<std::string>(opStack.top(), OP));
@@ -165,6 +165,8 @@ void rpnBuilder::handle_op(const std::string& op) {
     }
   }
   opStack.push(op);
+
+  lastTokenWasOp = op[0];
 }
 
 void rpnBuilder::open_bracket(const std::string& bracket) {
@@ -326,6 +328,7 @@ TokenQueue_t calculator::toRPN(const char* expr,
       ++expr;
       data.rpn.push(new Token<std::string>(ss.str(), STR));
       data.lastTokenWasOp = false;
+      data.lastTokenWasUnary = false;
     } else {
       // Otherwise, the variable is an operator or paranthesis.
       tokType_t lastType;
@@ -415,8 +418,6 @@ TokenQueue_t calculator::toRPN(const char* expr,
             }
           } else {
             data.handle_op(op);
-
-            data.lastTokenWasOp = op[0];
           }
         }
       }

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -332,8 +332,6 @@ TokenQueue_t calculator::toRPN(const char* expr,
       data.handle_token(new Token<std::string>(ss.str(), STR));
     } else {
       // Otherwise, the variable is an operator or paranthesis.
-      tokType_t lastType;
-      char lastOp;
 
       // Check for syntax errors (excess of operators i.e. 10 + + -1):
       if (data.lastTokenWasUnary) {
@@ -347,9 +345,7 @@ TokenQueue_t calculator::toRPN(const char* expr,
       switch (*expr) {
       case '(':
         // If it is a function call:
-        lastType = data.rpn.size() ? data.rpn.back()->type : NONE;
-        lastOp = data.opStack.size() ? data.opStack.top()[0] : '\0';
-        if (lastType == VAR || lastType == (FUNC | REF) || lastOp == '.') {
+        if (data.lastTokenWasOp == false) {
           // This counts as a bracket and as an operator:
           data.handle_op("()");
           // Add it as a bracket to the op stack:

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -544,7 +544,7 @@ TokenBase* calculator::calculate(const TokenQueue_t& rpn, TokenMap scope,
           cleanStack(evaluation);
           throw undefined_operation(data.op, r_left, p_right);
         }
-      } else if (b_left->type == FUNC) {
+      } else if (b_left->type == FUNC && data.op == "()") {
         Function* f_left = static_cast<Function*>(b_left);
 
         if (!data.op.compare("()")) {

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -131,6 +131,7 @@ struct rpnBuilder {
 
  public:
   void handle_op(const std::string& op);
+  void handle_token(TokenBase* token);
   void open_bracket(const std::string& bracket);
   void close_bracket(const std::string& bracket);
 

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -7,6 +7,7 @@
 #include <queue>
 #include <list>
 #include <vector>
+#include <set>
 
 /*
  * About tokType enum:
@@ -65,13 +66,33 @@ struct TokenNone : public TokenBase {
 
 class packToken;
 typedef std::queue<TokenBase*> TokenQueue_t;
-struct OppMap_t : public std::map<std::string, int> {
+class OppMap_t {
+  // Set of operators that should be evaluated from right to left:
+  std::set<std::string> RtoL;
+  // Map of operators precedence:
+  std::map<std::string, int> pr_map;
+
+ public:
   OppMap_t() {
     // These operations are hard-coded inside the calculator,
     // thus their precedence should always be defined:
-    (*this)["[]"] = -1; (*this)["()"] = -1;
-    (*this)["["] = 0x7FFFFFFF; (*this)["("] = 0x7FFFFFFF; (*this)["{"] = 0x7FFFFFFF;
+    pr_map["[]"] = -1; pr_map["()"] = -1;
+    pr_map["["] = 0x7FFFFFFF; pr_map["("] = 0x7FFFFFFF; pr_map["{"] = 0x7FFFFFFF;
+    RtoL.insert("=");
   }
+
+  void add(const std::string& op, int precedence) {
+    if (precedence < 0) {
+      RtoL.insert(op);
+      precedence = -precedence;
+    }
+
+    pr_map[op] = precedence;
+  }
+
+  int prec(const std::string& op) const { return pr_map.at(op); }
+  bool assoc(const std::string& op) const { return RtoL.count(op); }
+  bool exists(const std::string& op) const { return pr_map.count(op); }
 };
 
 class TokenMap;

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -246,6 +246,10 @@ TEST_CASE("Tuple usage expressions", "[tuple]") {
   REQUIRE(t2->list().size() == 2);
   delete t1;
   delete t2;
+
+  GlobalScope global;
+  REQUIRE_NOTHROW(c.compile("pow, None"));
+  REQUIRE(c.eval(global).str() == "([Function: pow], None)");
 }
 
 TEST_CASE("List and map constructors usage") {

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -213,6 +213,17 @@ TEST_CASE("List usage expressions", "[list]") {
   REQUIRE_THROWS(calculator::calculate("concat[-10]", vars));
   REQUIRE_THROWS(vars["concat"].asList()[10]);
   REQUIRE_THROWS(vars["concat"].asList()[-10]);
+
+  // Testing push and pop functions:
+  TokenList L;
+  REQUIRE_NOTHROW(L.push("my value"));
+  REQUIRE_NOTHROW(L.push(10));
+  REQUIRE_NOTHROW(L.push(TokenMap()));
+  REQUIRE_NOTHROW(L.push(TokenList()));
+
+  REQUIRE(packToken(L).str() == "[ \"my value\", 10, {}, [] ]");
+  REQUIRE(L.pop().str() == "[]");
+  REQUIRE(packToken(L).str() == "[ \"my value\", 10, {} ]");
 }
 
 TEST_CASE("Tuple usage expressions", "[tuple]") {

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -364,7 +364,7 @@ TEST_CASE("Function usage expressions") {
 
   REQUIRE_THROWS(calculator::calculate("foo(10)"));
   REQUIRE_THROWS(calculator::calculate("foo(10),"));
-  REQUIRE_THROWS(calculator::calculate("foo,(10)"));
+  REQUIRE_NOTHROW(calculator::calculate("foo,(10)"));
 
   REQUIRE(TokenMap::default_global()["abs"].str() == "[Function: abs]");
   REQUIRE(calculator::calculate("1,2,3,4,5").str() == "(1, 2, 3, 4, 5)");

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -211,6 +211,8 @@ TEST_CASE("List usage expressions", "[list]") {
   // List index out of range:
   REQUIRE_THROWS(calculator::calculate("concat[10]", vars));
   REQUIRE_THROWS(calculator::calculate("concat[-10]", vars));
+  REQUIRE_THROWS(vars["concat"].asList()[10]);
+  REQUIRE_THROWS(vars["concat"].asList()[-10]);
 }
 
 TEST_CASE("Tuple usage expressions", "[tuple]") {


### PR DESCRIPTION
Now if you want to define your operator to associate from right to left, instead of the default, i.e. from left to right you just need to define its priority as a negative number. The actual priority value used will be the mod of it, but when evaluating it will associate on the reverse order.

To allow that it was necessary to change a little the API:

```C++
OppMap_t& opp = calculator::default_opPrecedence();
// Before:
opp["my_op"] = my_op_priority;

// Now:
opp.add("my_op", -my_op_priority);
```

Minor bug fix: The TokenList operator[] now throws out_of_range exceptions instead of causing memory access errors. (to avoid this error check for speed just use the TokenList::list()::operator[] API)

Minor bug fix: The call operator `()` used to take over any operation with a Function on the left side. If the  operation was not a `()` it would throw an error, making it impossible for example to make a tuple of functions. This is fixed now, and the operator `()` will only be called when it is the actual current operator.

Add the `rpnBuilder::handle_token(TokenBase*)` and update the function `handle_op()` so that now all the mess of handling the internal flags: `lastTokenWasOp` and `lastTokenWasUnary` is hidden from our users. This also make the code less error prone and readable.

Last but not least, the call operator now will be called whenever you open a curly bracket after any operand. Before this commit it would only work if the operand was a variable, a function or an attribute of a list or map, what was overly complicated, and mostly just wrong.