### PR TITLE
Add some small improvements

### DIFF
--- a/builtin-features.cpp
+++ b/builtin-features.cpp
@@ -545,6 +545,41 @@ packToken string_upper(TokenMap scope) {
   return out;
 }
 
+packToken string_strip(TokenMap scope) {
+  std::string str = scope["this"].asString();
+
+  std::string::const_iterator it = str.begin();
+  while (it != str.end() && isspace(*it)) ++it;
+
+  std::string::const_reverse_iterator rit = str.rbegin();
+  while (rit.base() != it && isspace(*rit)) ++rit;
+
+  return std::string(it, rit.base());
+}
+
+packToken string_split(TokenMap scope) {
+  TokenList list;
+  std::string str = scope["this"].asString();
+  std::string split_chars = scope["chars"].asString();
+
+  // Split the string:
+  size_t start = 0;
+  size_t i = str.find(split_chars, 0);
+  size_t size = split_chars.size();
+  while (i < str.size()) {
+    // Add a new item:
+    list.push(std::string(str, start, i-start));
+    // Resume search:
+    start = i + size;
+    i = str.find(split_chars, start);
+  }
+
+  // Add a new item:
+  list.push(std::string(str, start, str.size()-start));
+
+  return list;
+}
+
 /* * * * * default constructor functions * * * * */
 
 packToken default_list(TokenMap scope) {
@@ -661,6 +696,8 @@ struct Startup {
     type_map[STR]["len"] = CppFunction(&string_len, "len");
     type_map[STR]["lower"] = CppFunction(&string_lower, "lower");
     type_map[STR]["upper"] = CppFunction(&string_upper, "upper");
+    type_map[STR]["strip"] = CppFunction(&string_strip, "strip");
+    type_map[STR]["split"] = CppFunction(&string_split, {"chars"}, "split");
   }
 } base_functions_startup;
 

--- a/builtin-features.cpp
+++ b/builtin-features.cpp
@@ -679,6 +679,8 @@ struct Startup {
     global["abs"] = CppFunction(&default_abs, num_arg, "abs");
     global["pow"] = CppFunction(&default_pow, pow_args, "pow");
     global["float"] = CppFunction(&default_float, value_arg, "float");
+    global["real"] = CppFunction(&default_float, value_arg, "real");
+    global["int"] = CppFunction(&default_int, value_arg, "int");
     global["str"] = CppFunction(&default_str, value_arg, "str");
     global["eval"] = CppFunction(&default_eval, value_arg, "eval");
     global["type"] = CppFunction(&default_type, value_arg, "type");

--- a/builtin-features.cpp
+++ b/builtin-features.cpp
@@ -58,7 +58,7 @@ packToken MapIndex(const packToken& p_left, const packToken& p_right, evaluation
     if (p_value) {
       return RefToken(right, *p_value, left);
     } else {
-      return RefToken(right, packToken::None, left);
+      return RefToken(right, packToken::None(), left);
     }
   } else {
     throw undefined_operation(op, left, right);
@@ -324,7 +324,7 @@ namespace builtin_reservedWords {
 // Literal Tokens: True, False and None:
 packToken trueToken = packToken(1);
 packToken falseToken = packToken(0);
-packToken noneToken = packToken::None;
+packToken noneToken = packToken::None();
 
 void True(const char* expr, const char** rest, rpnBuilder* data) {
   data->handle_token(trueToken->clone());
@@ -392,7 +392,7 @@ packToken default_print(TokenMap scope) {
 
   std::cout << std::endl;
 
-  return packToken::None;
+  return packToken::None();
 }
 
 packToken default_sum(TokenMap scope) {
@@ -724,7 +724,7 @@ packToken map_pop(TokenMap scope) {
   if (def) {
     return *def;
   } else {
-    return packToken::None;
+    return packToken::None();
   }
 }
 

--- a/builtin-features.cpp
+++ b/builtin-features.cpp
@@ -466,7 +466,7 @@ packToken default_type(TokenMap scope) {
   switch (tok->type) {
   case NONE: return "none";
   case VAR: return "variable";
-  case REAL: return "float";
+  case REAL: return "real";
   case INT: return "integer";
   case STR: return "string";
   case FUNC: return "function";

--- a/builtin-features.cpp
+++ b/builtin-features.cpp
@@ -776,6 +776,20 @@ packToken list_len(TokenMap scope) {
   return list.list().size();
 }
 
+packToken list_join(TokenMap scope) {
+  TokenList list = scope["this"].asList();
+  std::string chars = scope["chars"].asString();
+  std::stringstream result;
+
+  std::vector<packToken>::const_iterator it = list.list().begin();
+  result << it->asString();
+  for (++it; it != list.list().end(); ++it) {
+    result << chars << it->asString();
+  }
+
+  return result.str();
+}
+
 /* * * * * Initialize TokenList functions * * * * */
 
 struct Startup {
@@ -784,6 +798,7 @@ struct Startup {
     base_list["push"] = CppFunction(list_push, push_args, "push");
     base_list["pop"] = CppFunction(list_pop, list_pop_args, "pop");
     base_list["len"] = CppFunction(list_len, "len");
+    base_list["join"] = CppFunction(list_join, {"chars"}, "join");
 
     TokenMap& base_map = TokenMap::base_map();
     base_map["pop"] = CppFunction(map_pop, map_pop_args, "pop");

--- a/builtin-features.cpp
+++ b/builtin-features.cpp
@@ -283,7 +283,7 @@ struct Startup {
     // Create the operator precedence map based on C++ default
     // precedence order as described on cppreference website:
     // http://en.cppreference.com/w/cpp/language/operator_precedence
-    OppMap_t& opp = calculator::default_opPrecedence();
+    OppMap_t& opp = calculator::Default().opPrecedence;
     opp.add("[]", 2); opp.add("()", 2); opp.add(".", 2);
     opp.add("**", 3);
     opp.add("*",  5); opp.add("/", 5); opp.add("%", 5);
@@ -297,7 +297,7 @@ struct Startup {
     opp.add(",", 16);
 
     // Link operations to respective operators:
-    opMap_t& opMap = calculator::default_opMap();
+    opMap_t& opMap = calculator::Default().opMap;
     opMap.add({ANY_TYPE, ",", ANY_TYPE}, &Comma);
     opMap.add({ANY_TYPE, ":", ANY_TYPE}, &Colon);
     opMap.add({ANY_TYPE, "==", ANY_TYPE}, &Equal);
@@ -355,7 +355,7 @@ void SlashStarComment(const char* expr, const char** rest, rpnBuilder* data) {
 
 struct Startup {
   Startup() {
-    rWordMap_t& rwMap = calculator::default_rWordMap();
+    rWordMap_t& rwMap = calculator::Default().rWordMap;
     rwMap["True"] = &True;
     rwMap["False"] = &False;
     rwMap["None"] = &None;

--- a/builtin-features.cpp
+++ b/builtin-features.cpp
@@ -355,13 +355,13 @@ void SlashStarComment(const char* expr, const char** rest, rpnBuilder* data) {
 
 struct Startup {
   Startup() {
-    rWordMap_t& rwMap = calculator::Default().rWordMap;
-    rwMap["True"] = &True;
-    rwMap["False"] = &False;
-    rwMap["None"] = &None;
-    rwMap["#"] = &LineComment;
-    rwMap["//"] = &LineComment;
-    rwMap["/*"] = &SlashStarComment;
+    parserMap_t& parser = calculator::Default().parserMap;
+    parser.add("True", &True);
+    parser.add("False", &False);
+    parser.add("None", &None);
+    parser.add("#", &LineComment);
+    parser.add("//", &LineComment);
+    parser.add("/*", &SlashStarComment);
   }
 } Startup;
 

--- a/functions.cpp
+++ b/functions.cpp
@@ -67,7 +67,7 @@ packToken Function::call(packToken _this, Function* func,
   for (; names_it != arg_names.end(); ++names_it) {
     // If not set by a keyword argument:
     if (local.map().count(*names_it) == 0) {
-      local[*names_it] = packToken::None;
+      local[*names_it] = packToken::None();
     }
   }
 

--- a/objects.cpp
+++ b/objects.cpp
@@ -30,7 +30,7 @@ TokenMap TokenMap::empty = TokenMap(&default_global());
 
 /* * * * * Iterator functions * * * * */
 
-Iterator*  Iterator::getIterator() {
+Iterator*  Iterator::getIterator() const {
   return static_cast<Iterator*>(this->clone());
 }
 

--- a/objects.h
+++ b/objects.h
@@ -15,7 +15,7 @@ class Iterator;
 
 struct Iterable : public TokenBase {
   virtual ~Iterable() {}
-  virtual Iterator* getIterator() = 0;
+  virtual Iterator* getIterator() const = 0;
 };
 
 // Iterator super class.
@@ -28,7 +28,7 @@ struct Iterator : public Iterable {
   virtual packToken* next() = 0;
   virtual void reset() = 0;
 
-  Iterator* getIterator();
+  Iterator* getIterator() const;
 };
 
 class TokenMap;
@@ -74,7 +74,7 @@ struct TokenMap : public pack<MapData_t>, public Iterable {
     }
   };
 
-  Iterator* getIterator() {
+  Iterator* getIterator() const {
     return new MapIterator(map());
   }
 
@@ -136,7 +136,7 @@ class TokenList : public pack<TokenList_t>, public Iterable {
     }
   };
 
-  Iterator* getIterator() {
+  Iterator* getIterator() const {
     return new ListIterator(&list());
   }
 

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -6,7 +6,10 @@
 #include "./packToken.h"
 #include "./shunting-yard-exceptions.h"
 
-const packToken packToken::None = packToken(TokenNone());
+const packToken& packToken::None() {
+  static packToken none = packToken(TokenNone());
+  return none;
+}
 
 packToken::packToken(const TokenMap& map) : base(new TokenMap(map)) {}
 packToken::packToken(const TokenList& list) : base(new TokenList(list)) {}

--- a/packToken.h
+++ b/packToken.h
@@ -8,7 +8,7 @@ class packToken {
   TokenBase* base;
 
  public:
-  static const packToken None;
+  static const packToken& None();
 
  public:
   packToken() : base(new TokenNone()) {}

--- a/packToken.h
+++ b/packToken.h
@@ -40,6 +40,7 @@ class packToken {
   operator TokenBase*() { return base; }
   operator const TokenBase*() const { return base; }
   TokenBase* token() { return base; }
+  const TokenBase* token() const { return base; }
 
   bool asBool() const;
   double asDouble() const;

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -86,25 +86,15 @@ TokenBase* resolve_reference(TokenBase* b, TokenMap* scope = 0) {
 
 /* * * * * Static containers: * * * * */
 
-// Builds the opPrecedence map only once:
-OppMap_t& calculator::default_opPrecedence() {
-  static OppMap_t opp;
-  return opp;
+// Build configurations once only:
+Config_t& calculator::Default() {
+  static Config_t conf;
+  return conf;
 }
 
 typeMap_t& calculator::type_attribute_map() {
   static typeMap_t type_map;
   return type_map;
-}
-
-opMap_t& calculator::default_opMap() {
-  static opMap_t opMap;
-  return opMap;
-}
-
-rWordMap_t& calculator::default_rWordMap() {
-  static rWordMap_t rwMap;
-  return rwMap;
 }
 
 /* * * * * rpnBuilder Class: * * * * */
@@ -227,9 +217,8 @@ struct calculator::RAII_TokenQueue_t : TokenQueue_t {
 #define isvariablechar(c) (isalpha(c) || c == '_')
 TokenQueue_t calculator::toRPN(const char* expr,
                                TokenMap vars, const char* delim,
-                               const char** rest, OppMap_t opPrecedence,
-                               rWordMap_t rWordMap) {
-  rpnBuilder data(vars, opPrecedence);
+                               const char** rest, Config_t config) {
+  rpnBuilder data(vars, config.opPrecedence);
   char* nextChar;
 
   static char c = '\0';
@@ -259,6 +248,7 @@ TokenQueue_t calculator::toRPN(const char* expr,
       expr = nextChar;
     } else if (isvariablechar(*expr)) {
       rWordMap_t::iterator it;
+      rWordMap_t& wmap = config.rWordMap;
 
       // If the token is a variable, resolve it and
       // add the parsed number to the output queue.
@@ -273,7 +263,7 @@ TokenQueue_t calculator::toRPN(const char* expr,
 
       if (data.lastTokenWasOp == '.') {
         data.handle_token(new Token<std::string>(key, STR));
-      } else if ((it=rWordMap.find(key)) != rWordMap.end()) {
+      } else if ((it=wmap.find(key)) != wmap.end()) {
         // Parse reserved words:
         try {
           it->second(expr, &expr, &data);
@@ -403,7 +393,8 @@ TokenQueue_t calculator::toRPN(const char* expr,
           std::string op = ss.str();
 
           rWordMap_t::iterator it;
-          if ((it=rWordMap.find(op)) != rWordMap.end()) {
+          rWordMap_t& wmap = config.rWordMap;
+          if ((it=wmap.find(op)) != wmap.end()) {
             // Parse reserved operators:
             try {
               it->second(expr, &expr, &data);
@@ -457,8 +448,8 @@ void cleanStack(std::stack<TokenBase*> st) {
 }
 
 TokenBase* calculator::calculate(const TokenQueue_t& rpn, TokenMap scope,
-                                 const opMap_t& opMap) {
-  evaluationData data(rpn, scope, opMap);
+                                 const Config_t& config) {
+  evaluationData data(rpn, scope, config.opMap);
 
   // Evaluate the expression in RPN form.
   std::stack<TokenBase*> evaluation;
@@ -653,9 +644,8 @@ calculator::calculator(const calculator& calc) {
 // - Stops at delim or '\0'
 // - Returns the rest of the string as char* rest
 calculator::calculator(const char* expr, TokenMap vars, const char* delim,
-                       const char** rest, const OppMap_t& opp,
-                       const rWordMap_t& rwMap) {
-  this->RPN = calculator::toRPN(expr, vars, delim, rest, opp, rwMap);
+                       const char** rest, const Config_t& config) {
+  this->RPN = calculator::toRPN(expr, vars, delim, rest, config);
 }
 
 void calculator::compile(const char* expr, TokenMap vars, const char* delim,
@@ -663,12 +653,11 @@ void calculator::compile(const char* expr, TokenMap vars, const char* delim,
   // Make sure it is empty:
   rpnBuilder::cleanRPN(&this->RPN);
 
-  this->RPN = calculator::toRPN(expr, vars, delim, rest,
-                                opPrecedence(), rWordMap());
+  this->RPN = calculator::toRPN(expr, vars, delim, rest, Config());
 }
 
 packToken calculator::eval(TokenMap vars, bool keep_refs) const {
-  TokenBase* value = calculate(this->RPN, vars, opMap());
+  TokenBase* value = calculate(this->RPN, vars, Config());
   packToken p = packToken(value->clone());
   if (keep_refs) {
     return packToken(value);

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -162,9 +162,9 @@ struct RefToken : public TokenBase {
   packToken key;
   packToken value;
   packToken source;
-  RefToken(packToken k, TokenBase* v, packToken m = packToken::None) :
+  RefToken(packToken k, TokenBase* v, packToken m = packToken::None()) :
     key(k), value(v), source(m) { this->type = v->type | REF; }
-  RefToken(packToken k, packToken v, packToken m = packToken::None) :
+  RefToken(packToken k, packToken v, packToken m = packToken::None()) :
     key(k), value(v), source(m) { this->type = v->type | REF; }
 
   virtual TokenBase* clone() const {

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -153,10 +153,46 @@ struct evaluationData {
 };
 
 // The reservedWordParser_t is the function type called when
-// a reserved word is found at parsing time.
+// a reserved word or character is found at parsing time.
 typedef void rWordParser_t(const char* expr, const char** rest,
                            rpnBuilder* data);
 typedef std::map<std::string, rWordParser_t*> rWordMap_t;
+typedef std::map<char, rWordParser_t*> rCharMap_t;
+
+struct parserMap_t {
+  rWordMap_t wmap;
+  rCharMap_t cmap;
+
+  // Add reserved word:
+  void add(const std::string& word, const rWordParser_t* parser) {
+    wmap[word] = parser;
+  }
+
+  // Add reserved character:
+  void add(char c, const rWordParser_t* parser) {
+    cmap[c] = parser;
+  }
+
+  rWordParser_t* find(const std::string text) {
+    rWordMap_t::iterator w_it;
+
+    if ((w_it=wmap.find(text)) != wmap.end()) {
+      return w_it->second;
+    }
+
+    return 0;
+  }
+
+  rWordParser_t* find(char c) {
+    rCharMap_t::iterator c_it;
+
+    if ((c_it=cmap.find(c)) != cmap.end()) {
+      return c_it->second;
+    }
+
+    return 0;
+  }
+};
 
 struct RefToken : public TokenBase {
   packToken key;
@@ -217,13 +253,13 @@ struct opMap_t : public std::map<std::string, opList_t> {
 };
 
 struct Config_t {
-  rWordMap_t rWordMap;
+  parserMap_t parserMap;
   OppMap_t opPrecedence;
   opMap_t opMap;
 
   Config_t() {}
-  Config_t(rWordMap_t w, OppMap_t opp, opMap_t opMap)
-          : rWordMap(w), opPrecedence(opp), opMap(opMap) {};
+  Config_t(parserMap_t p, OppMap_t opp, opMap_t opMap)
+          : parserMap(p), opPrecedence(opp), opMap(opMap) {};
 };
 
 class calculator {

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -259,7 +259,7 @@ struct Config_t {
 
   Config_t() {}
   Config_t(parserMap_t p, OppMap_t opp, opMap_t opMap)
-          : parserMap(p), opPrecedence(opp), opMap(opMap) {};
+          : parserMap(p), opPrecedence(opp), opMap(opMap) {}
 };
 
 class calculator {

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -216,11 +216,19 @@ struct opMap_t : public std::map<std::string, opList_t> {
   }
 };
 
+struct Config_t {
+  rWordMap_t rWordMap;
+  OppMap_t opPrecedence;
+  opMap_t opMap;
+
+  Config_t() {}
+  Config_t(rWordMap_t w, OppMap_t opp, opMap_t opMap)
+          : rWordMap(w), opPrecedence(opp), opMap(opMap) {};
+};
+
 class calculator {
  public:
-  static rWordMap_t& default_rWordMap();
-  static OppMap_t& default_opPrecedence();
-  static opMap_t& default_opMap();
+  static Config_t& Default();
 
  public:
   static typeMap_t& type_attribute_map();
@@ -231,20 +239,17 @@ class calculator {
 
  public:
   static TokenBase* calculate(const TokenQueue_t& RPN, TokenMap scope,
-                              const opMap_t& opMap = default_opMap());
+                              const Config_t& config = Default());
   static TokenQueue_t toRPN(const char* expr, TokenMap vars,
                             const char* delim = 0, const char** rest = 0,
-                            OppMap_t opPrecedence = default_opPrecedence(),
-                            rWordMap_t rWordMap = default_rWordMap());
+                            Config_t config = Default());
 
  public:
   // Used to dealloc a TokenQueue_t safely.
   struct RAII_TokenQueue_t;
 
  protected:
-  virtual const opMap_t opMap() const { return default_opMap(); }
-  virtual const OppMap_t opPrecedence() const { return default_opPrecedence(); }
-  virtual const rWordMap_t rWordMap() const { return default_rWordMap(); }
+  virtual const Config_t Config() const { return Default(); }
 
  private:
   TokenQueue_t RPN;
@@ -255,8 +260,7 @@ class calculator {
   calculator(const calculator& calc);
   calculator(const char* expr, TokenMap vars = &TokenMap::empty,
              const char* delim = 0, const char** rest = 0,
-             const OppMap_t& opPrecedence = default_opPrecedence(),
-             const rWordMap_t& rwMap = default_rWordMap());
+             const Config_t& config = Default());
   void compile(const char* expr, TokenMap vars = &TokenMap::empty,
                const char* delim = 0, const char** rest = 0);
   packToken eval(TokenMap vars = &TokenMap::empty, bool keep_refs = false) const;

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -452,11 +452,15 @@ TEST_CASE("Default functions") {
 
 TEST_CASE("Type specific functions") {
   TokenMap vars;
-  vars["s"] = "String";
+  vars["s1"] = "String";
+  vars["s2"] = " a b ";
+  vars["s3"] = "a,b";
 
-  REQUIRE(calculator::calculate("s.len()", vars).asDouble() == 6);
-  REQUIRE(calculator::calculate("s.lower()", vars).asString() == "string");
-  REQUIRE(calculator::calculate("s.upper()", vars).asString() == "STRING");
+  REQUIRE(calculator::calculate("s1.len()", vars).asDouble() == 6);
+  REQUIRE(calculator::calculate("s1.lower()", vars).asString() == "string");
+  REQUIRE(calculator::calculate("s1.upper()", vars).asString() == "STRING");
+  REQUIRE(calculator::calculate("s2.strip()", vars).asString() == "a b");
+  REQUIRE(calculator::calculate("s3.split(',')", vars).str() == "[ \"a\", \"b\" ]");
 }
 
 TEST_CASE("Assignment expressions") {

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -454,13 +454,17 @@ TEST_CASE("Type specific functions") {
   TokenMap vars;
   vars["s1"] = "String";
   vars["s2"] = " a b ";
-  vars["s3"] = "a,b";
 
   REQUIRE(calculator::calculate("s1.len()", vars).asDouble() == 6);
   REQUIRE(calculator::calculate("s1.lower()", vars).asString() == "string");
   REQUIRE(calculator::calculate("s1.upper()", vars).asString() == "STRING");
   REQUIRE(calculator::calculate("s2.strip()", vars).asString() == "a b");
-  REQUIRE(calculator::calculate("s3.split(',')", vars).str() == "[ \"a\", \"b\" ]");
+
+  calculator c1("L = 'a, b'.split(', ')", vars);
+  REQUIRE(c1.eval(vars).str() == "[ \"a\", \"b\" ]");
+
+  calculator c2("L.join(', ')");
+  REQUIRE(c2.eval(vars).asString() == "a, b");
 }
 
 TEST_CASE("Assignment expressions") {

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -122,7 +122,7 @@ TEST_CASE("Map access expressions") {
 
   REQUIRE(calculator::calculate("map.key3.map1", vars).asString() == "inception1");
   REQUIRE(calculator::calculate("map.key3['map2']", vars).asString() == "inception2");
-  REQUIRE(calculator::calculate("map[\"no_key\"]", vars) == packToken::None);
+  REQUIRE(calculator::calculate("map[\"no_key\"]", vars) == packToken::None());
 }
 
 TEST_CASE("Prototypical inheritance tests") {

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -442,7 +442,7 @@ TEST_CASE("Passing keyword arguments to functions") {
 
 TEST_CASE("Default functions") {
   REQUIRE(calculator::calculate("type(None)").asString() == "none");
-  REQUIRE(calculator::calculate("type(10.0)").asString() == "float");
+  REQUIRE(calculator::calculate("type(10.0)").asString() == "real");
   REQUIRE(calculator::calculate("type(10)").asString() == "integer");
   REQUIRE(calculator::calculate("type('str')").asString() == "string");
   REQUIRE(calculator::calculate("type(str)").asString() == "function");

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -605,30 +605,24 @@ TEST_CASE("operation_id() function", "[op_id]") {
 /* * * * * Declaring adhoc operations * * * * */
 
 struct myCalc : public calculator {
-  static opMap_t& my_opMap() {
-    static opMap_t opMap;
-    return opMap;
+  static Config_t& my_config() {
+    static Config_t conf;
+    return conf;
   }
 
-  static OppMap_t& my_OppMap() {
-    static OppMap_t opp;
-    return opp;
-  }
-
-  const opMap_t opMap() const { return my_opMap(); }
-  const OppMap_t opPrecedence() const { return my_OppMap(); }
+  const Config_t Config() const { return my_config(); }
 
   using calculator::calculator;
 };
 
 packToken op1(const packToken& left, const packToken& right,
               evaluationData* data) {
-  return calculator::default_opMap()["%"][0].exec(left, right, data);
+  return calculator::Default().opMap["%"][0].exec(left, right, data);
 }
 
 packToken op2(const packToken& left, const packToken& right,
               evaluationData* data) {
-  return calculator::default_opMap()[","][0].exec(left, right, data);
+  return calculator::Default().opMap[","][0].exec(left, right, data);
 }
 
 packToken op3(const packToken& left, const packToken& right,
@@ -643,14 +637,14 @@ packToken op4(const packToken& left, const packToken& right,
 
 struct myCalcStartup {
   myCalcStartup() {
-    OppMap_t& opp = myCalc::my_OppMap();
+    OppMap_t& opp = myCalc::my_config().opPrecedence;
     opp.add(".", 1);
     opp.add("+", 2); opp.add("*", 2);
 
     // This operator will evaluate from right to left:
     opp.add("-", -3);
 
-    opMap_t& opMap = myCalc::my_opMap();
+    opMap_t& opMap = myCalc::my_config().opMap;
     opMap.add({STR, "+", TUPLE}, &op1);
     opMap.add({ANY_TYPE, ".", ANY_TYPE}, &op2);
     opMap.add({NUM, "-", NUM}, &op3);
@@ -664,7 +658,7 @@ TEST_CASE("Adhoc operations", "[operation]") {
   myCalc c1, c2;
   const char* exp = "'Lets create %s operators%s' + ('adhoc' . '!' )";
   REQUIRE_NOTHROW(c1.compile(exp));
-  REQUIRE_NOTHROW(c2 = myCalc(exp, vars, 0, 0, myCalc::my_OppMap()));
+  REQUIRE_NOTHROW(c2 = myCalc(exp, vars, 0, 0, myCalc::my_config()));
 
   REQUIRE(c1.eval() == "Lets create adhoc operators!");
   REQUIRE(c2.eval() == "Lets create adhoc operators!");


### PR DESCRIPTION

1. Add the concept of `reserved character` 08aecfd, changing the way to add reserved words, and allowing for reserving the meaning of single characters regardless if they are followed by other characters that look like operators, e.g.: `/my reg exp/ or /!my reg exp/`, in both cases the character `/` should trigger the evaluation of a regular expression, and that was not possible before where `/!` would be missinterpreted as an operator. Now to the syntax for adding a reserved word or character is this:

  ```C++
  parserMap_t& parser = calculator::Default().parserMap;

  parser.add("new", &new_behavior);
  parser.add('/', &regex_delimiter);
  ```

2. Make an important refactor on 44bdcec that groups together `OppMap_t`, `rWordMap_t` and `opMap_t` into a class named `Config_t`. To access these values is now possible like this:
  
  - calculator::Default().opPrecedence
  - calculator::Default().opMap
  - calculator::Default().rWordMap

3. Fix an important bug  f64f1c4 that could lead to segmentation fault.

4. Update some built-in functions and add others.
