### PR TITLE
Lack of proper forwarding was causing packToken(const packToken&) to …

### DIFF
--- a/packToken.h
+++ b/packToken.h
@@ -76,13 +76,6 @@ class packToken {
  public:
   // Used to recover the original pointer.
   // The intance whose pointer was removed must be an rvalue.
-  TokenBase* release() & {
-    TokenBase* b = base;
-    // Setting base to 0 leaves the class in an invalid state,
-    // except for destruction.
-    base = 0;
-    return b;
-  }
   TokenBase* release() && {
     TokenBase* b = base;
     // Setting base to 0 leaves the class in an invalid state,

--- a/packToken.h
+++ b/packToken.h
@@ -76,6 +76,13 @@ class packToken {
  public:
   // Used to recover the original pointer.
   // The intance whose pointer was removed must be an rvalue.
+  TokenBase* release() & {
+    TokenBase* b = base;
+    // Setting base to 0 leaves the class in an invalid state,
+    // except for destruction.
+    base = 0;
+    return b;
+  }
   TokenBase* release() && {
     TokenBase* b = base;
     // Setting base to 0 leaves the class in an invalid state,

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -282,7 +282,7 @@ class RefToken : public TokenBase {
   RefToken(packToken k, TokenBase* v, packToken m = packToken::None()) :
     TokenBase(v->type | REF), original_value(std::forward<packToken>(v)), key(std::forward<packToken>(k)), origin(std::forward<packToken>(m)) {}
   RefToken(packToken k = packToken::None(), packToken v = packToken::None(), packToken m = packToken::None()) :
-    TokenBase(v->type | REF), original_value(v), key(k), origin(std::forward<packToken>(m)) {}
+    TokenBase(v->type | REF), original_value(std::forward<packToken>(v)), key(std::forward<packToken>(k)), origin(std::forward<packToken>(m)) {}
 
   TokenBase* resolve(TokenMap* localScope = 0) const {
     TokenBase* result = 0;

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -280,7 +280,7 @@ class RefToken : public TokenBase {
   packToken key;
   packToken origin;
   RefToken(packToken k, TokenBase* v, packToken m = packToken::None()) :
-    TokenBase(v->type | REF), original_value(std::forward<packToken>(v)), key(std::forward<packToken>(k)), origin(std::forward<packToken>(m)) {}
+    TokenBase(v->type | REF), original_value(v), key(std::forward<packToken>(k)), origin(std::forward<packToken>(m)) {}
   RefToken(packToken k = packToken::None(), packToken v = packToken::None(), packToken m = packToken::None()) :
     TokenBase(v->type | REF), original_value(std::forward<packToken>(v)), key(std::forward<packToken>(k)), origin(std::forward<packToken>(m)) {}
 

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -280,9 +280,9 @@ class RefToken : public TokenBase {
   packToken key;
   packToken origin;
   RefToken(packToken k, TokenBase* v, packToken m = packToken::None()) :
-    TokenBase(v->type | REF), original_value(v), key(k), origin(m) {}
+    TokenBase(v->type | REF), original_value(std::forward<packToken>(v)), key(std::forward<packToken>(k)), origin(std::forward<packToken>(m)) {}
   RefToken(packToken k = packToken::None(), packToken v = packToken::None(), packToken m = packToken::None()) :
-    TokenBase(v->type | REF), original_value(v), key(k), origin(m) {}
+    TokenBase(v->type | REF), original_value(v), key(k), origin(std::forward<packToken>(m)) {}
 
   TokenBase* resolve(TokenMap* localScope = 0) const {
     TokenBase* result = 0;

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -11,6 +11,7 @@
 #include <set>
 #include <sstream>
 #include <memory>
+#include <utility>
 
 /*
  * About tokType enum:


### PR DESCRIPTION
…be called instead of packToken(packToken&&), given this, the destructor of the local pass in arguments was also not being called, causing the cloned packTokens to be definitely lost

valgrind:memcheck 387,960 bytes in 16,165 blocks are definitely lost in loss record 261 of 267
valgrind:memcheck    at 0x4C2A203: operator new(unsigned long) (vg_replace_malloc.c:334)
valgrind:memcheck    by 0x1D7FD5A: Token<double>::clone() const (shunting-yard.h:71)
valgrind:memcheck    by 0x1D67CB9: RefToken::RefToken(packToken, TokenBase*, packToken) (shunting-yard.h:285)
valgrind:memcheck    by 0x1D623FA: ec::InterpreterImpl::process(std::queue<TokenBase*, std::deque<TokenBase*, std::allocator<TokenBase*> > > const&, TokenMap, Config_t const&) (interpreter.cpp:597)
valgrind:memcheck    by 0x1D62CB8: ec::InterpreterImpl::eval(TokenMap, bool) const (interpreter.cpp:645)
valgrind:memcheck    by 0x1D5E953: ec::ExpStatement::_exec(TokenMap) const (interpreter.cpp:17)
valgrind:memcheck    by 0x1D68E1D: ec::Statement::exec(TokenMap) const (interpreter.h:101)
valgrind:memcheck    by 0x1D5F2BB: ec::BlockStatement::_exec(TokenMap) const (interpreter.cpp:116)
valgrind:memcheck    by 0x1D68E1D: ec::Statement::exec(TokenMap) const (interpreter.h:101)
valgrind:memcheck    by 0x27DB10E: ec::el::Interpreter::exec(TokenMap&) (interpreter.h:385)
valgrind:memcheck    by 0x27CCFCA: ec::UniverseDescriptor::render_universe(ec::ReferenceData const&) (trading_core.cpp:638)
valgrind:memcheck    by 0x27BF284: ec::tests::test_universe_product_selection::test_service_test_trading_strategy_reactor_02_07_21::execute_test() (test_trading_strategy_reactor_02_07.cpp:165)