### PR TITLE
Make ld -O1 option conditional to Linux builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,20 @@ CXX ?= g++
 CFLAGS = -std=c++11 -Wall -pedantic -Wmissing-field-initializers -Wuninitialized
 DEBUG = -g #-DDEBUG
 
+ifeq ($(OS),Windows_NT) # is Windows_NT on XP, 2000, 7, Vista, 10...
+	detected_OS := Windows
+else
+	detected_OS := $(shell uname)
+endif
+
+LDFLAGS=
+ifeq ($(detected_OS), Linux)
+	LDFLAGS += -O1
+endif
+
 release: $(CORE_SRC:.cpp=.o) builtin-features.cpp;
 	$(CXX) -c -O3 $(CFLAGS) builtin-features.cpp
-	$(LD) -r -O1 $(CORE_SRC:.cpp=.o) -o core-shunting-yard.o
+	$(LD) -r $(LDFLAGS) $(CORE_SRC:.cpp=.o) -o core-shunting-yard.o
 
 all: $(EXE) release
 


### PR DESCRIPTION
This was changed because this options is not recognized on macOS
and possibly Windows too.