### PR TITLE
Normalize unary operator in error message

### DIFF
--- a/catch.cpp
+++ b/catch.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_RUNNER
-#include "catch.hpp"
+#include "./catch.hpp"
 
 // Defined on test-shunting-yard.cpp
 void PREPARE_ENVIRONMENT();

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -10,6 +10,7 @@
 #include <stack>
 #include <utility>  // For std::pair
 #include <cstring>  // For strchr()
+#include <cstdlib>  // For strtoll()
 
 using cparse::calculator;
 using cparse::packToken;
@@ -490,7 +491,7 @@ TokenQueue_t calculator::toRPN(const char* expr,
   // Check for syntax errors (excess of operators i.e. 10 + + -1):
   if (data.lastTokenWasUnary) {
     rpnBuilder::cleanRPN(&data.rpn);
-    throw syntax_error("Expected operand after unary operator `" + data.opStack.top() + "`");
+    throw syntax_error("Expected operand after unary operator `" + normalize_op(data.opStack.top()) + "`");
   }
 
   std::string cur_op;

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -10,7 +10,6 @@
 #include <stack>
 #include <utility>  // For std::pair
 #include <cstring>  // For strchr()
-#include <cstdlib>  // For strtoll()
 
 using cparse::calculator;
 using cparse::packToken;
@@ -694,7 +693,7 @@ packToken calculator::eval(TokenMap vars, bool keep_refs) const {
 
 std::unordered_set<std::string> calculator::get_variables() const {
   std::unordered_set<std::string> vars;
-  for (const auto& i: RPN) {
+  for (const auto& i : RPN) {
     if (i->type == tokType::VAR) {
       vars.insert(static_cast<Token<std::string>*>(i)->val);
     }

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -93,7 +93,7 @@ class packToken;
 
 // Adapt to std::queue<TokenBase*>
 class TokenQueue_t: public std::deque<TokenBase*> {
-public:
+ public:
   void push(TokenBase* t) {
     push_back(t);
   }

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -4,6 +4,7 @@
 #include "catch.hpp"
 
 #include "./shunting-yard.h"
+#include "./shunting-yard-exceptions.h"
 
 using cparse::calculator;
 using cparse::packToken;
@@ -1181,4 +1182,9 @@ TEST_CASE("Get variables") {
   calculator c("a + sin(b) - c**2 / d");
   auto expectedVars = std::unordered_set<std::string>{"a", "b", "c", "d"};
   REQUIRE(c.get_variables() == expectedVars);
+}
+
+TEST_CASE("Unary operator error") {
+  calculator ecalc;
+  REQUIRE_THROWS_WITH(ecalc.compile("+"), "Expected operand after unary operator `+`");
 }

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include "catch.hpp"
+#include "./catch.hpp"
 
 #include "./shunting-yard.h"
 #include "./shunting-yard-exceptions.h"


### PR DESCRIPTION
See included test.

Compiling an expression containing a stray plus symbol used to throw an error message that said "Expected operand after unary operator `L+`". Calling normalize_op when building this message results in the much friendlier "Expected operand after unary operator `+`" (without the L).
