### PR TITLE
Fix MSVC warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OBJ = $(SRC:.cpp=.o)
 
 LD ?= ld
 CXX ?= g++
-CFLAGS = -std=c++11 -Wall -pedantic -Wmissing-field-initializers -Wuninitialized
+CFLAGS = -std=c++11 -Wall -pedantic -Wmissing-field-initializers -Wuninitialized -Wsign-compare
 DEBUG = -g #-DDEBUG
 
 ifeq ($(OS),Windows_NT) # is Windows_NT on XP, 2000, 7, Vista, 10...

--- a/builtin-features/operations.inc
+++ b/builtin-features/operations.inc
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <cstddef>
 
 namespace builtin_operations {
 

--- a/builtin-features/operations.inc
+++ b/builtin-features/operations.inc
@@ -311,7 +311,7 @@ packToken ListOnNumberOperation(const packToken& p_left, const packToken& p_righ
 
     packToken& value = left.list()[index];
 
-    return RefToken(index, value, p_left);
+    return RefToken(static_cast<int64_t>(index), value, p_left);
   } else {
     throw undefined_operation(data->op, p_left, p_right);
   }

--- a/builtin-features/operations.inc
+++ b/builtin-features/operations.inc
@@ -263,7 +263,7 @@ packToken StringOnNumberOperation(const packToken& p_left, const packToken& p_ri
     ss << left << p_right.asDouble();
     return ss.str();
   } else if (op == "[]") {
-    size_t index = static_cast<size_t>(p_right.asInt());
+    ptrdiff_t index = static_cast<ptrdiff_t>(p_right.asInt());
 
     if (index < 0) {
       // Reverse index, i.e. list[-1] = list[list.size()-1]
@@ -297,14 +297,14 @@ packToken ListOnNumberOperation(const packToken& p_left, const packToken& p_righ
   TokenList left = p_left.asList();
 
   if (data->op == "[]") {
-    size_t index = static_cast<size_t>(p_right.asInt());
+    ptrdiff_t index = static_cast<ptrdiff_t>(p_right.asInt());
 
     if (index < 0) {
       // Reverse index, i.e. list[-1] = list[list.size()-1]
       index += left.list().size();
     }
 
-    if (index < 0 || index >= left.list().size()) {
+    if (index < 0 || static_cast<size_t>(index) >= left.list().size()) {
       throw std::domain_error("List index out of range!");
     }
 

--- a/builtin-features/operations.inc
+++ b/builtin-features/operations.inc
@@ -35,7 +35,7 @@ packToken Assign(const packToken& left, const packToken& right, evaluationData* 
   } else if (key->type & NUM) {
     if (origin->type == LIST) {
       TokenList& list = origin.asList();
-      size_t index = key.asInt();
+      size_t index = static_cast<size_t>(key.asInt());
       list[index] = right;
     } else {
       throw std::domain_error("Left operand of assignment is not a list!");
@@ -263,7 +263,7 @@ packToken StringOnNumberOperation(const packToken& p_left, const packToken& p_ri
     ss << left << p_right.asDouble();
     return ss.str();
   } else if (op == "[]") {
-    int64_t index = p_right.asInt();
+    size_t index = static_cast<size_t>(p_right.asInt());
 
     if (index < 0) {
       // Reverse index, i.e. list[-1] = list[list.size()-1]
@@ -297,14 +297,14 @@ packToken ListOnNumberOperation(const packToken& p_left, const packToken& p_righ
   TokenList left = p_left.asList();
 
   if (data->op == "[]") {
-    int64_t index = p_right.asInt();
+    size_t index = static_cast<size_t>(p_right.asInt());
 
     if (index < 0) {
       // Reverse index, i.e. list[-1] = list[list.size()-1]
       index += left.list().size();
     }
 
-    if (index < 0 || static_cast<size_t>(index) >= left.list().size()) {
+    if (index < 0 || index >= left.list().size()) {
       throw std::domain_error("List index out of range!");
     }
 

--- a/builtin-features/typeSpecificFunctions.inc
+++ b/builtin-features/typeSpecificFunctions.inc
@@ -63,10 +63,10 @@ packToken list_pop(TokenMap scope) {
   TokenList list = scope.find("this")->asList();
   packToken* token = scope.find("pos");
 
-  int64_t pos;
+  size_t pos;
 
   if ((*token)->type & NUM) {
-    pos = token->asInt();
+    pos = static_cast<size_t>(token->asInt());
 
     // So that pop(-1) is the same as pop(last_idx):
     if (pos < 0) pos = list.list().size()-pos;
@@ -113,7 +113,7 @@ packToken string_lower(TokenMap scope) {
   std::string str = scope["this"].asString();
   std::string out;
   for (char c : str) {
-    out.push_back(tolower(c));
+    out.push_back(static_cast<char>(tolower(c)));
   }
   return out;
 }
@@ -122,7 +122,7 @@ packToken string_upper(TokenMap scope) {
   std::string str = scope["this"].asString();
   std::string out;
   for (char c : str) {
-    out.push_back(toupper(c));
+    out.push_back(static_cast<char>(toupper(c)));
   }
   return out;
 }

--- a/catch.cpp
+++ b/catch.cpp
@@ -1,5 +1,5 @@
 #define CATCH_CONFIG_RUNNER
-#include "catch.hpp"
+#include "./catch.hpp"
 
 // Defined on test-shunting-yard.cpp
 void PREPARE_ENVIRONMENT();

--- a/containers.h
+++ b/containers.h
@@ -145,7 +145,7 @@ struct TokenList : public Container<TokenList_t>, public Iterable {
  public:
   struct ListIterator : public Iterator {
     TokenList_t* list;
-    uint64_t i = 0;
+    size_t i = 0;
 
     ListIterator(TokenList_t* list) : list(list) {}
 
@@ -165,7 +165,7 @@ struct TokenList : public Container<TokenList_t>, public Iterable {
   TokenList() { this->type = LIST; }
   virtual ~TokenList() {}
 
-  packToken& operator[](const uint64_t idx) const {
+  packToken& operator[](const size_t idx) const {
     if (list().size() <= idx) {
       throw std::out_of_range("List index out of range!");
     }

--- a/packToken.cpp
+++ b/packToken.cpp
@@ -115,7 +115,7 @@ double packToken::asDouble() const {
   case REAL:
     return static_cast<Token<double>*>(base)->val;
   case INT:
-    return static_cast<Token<int64_t>*>(base)->val;
+    return static_cast<double>(static_cast<Token<int64_t>*>(base)->val);
   case BOOL:
     return static_cast<Token<uint8_t>*>(base)->val;
   default:
@@ -132,7 +132,7 @@ double packToken::asDouble() const {
 int64_t packToken::asInt() const {
   switch (base->type) {
   case REAL:
-    return static_cast<Token<double>*>(base)->val;
+    return static_cast<int64_t>(static_cast<Token<double>*>(base)->val);
   case INT:
     return static_cast<Token<int64_t>*>(base)->val;
   case BOOL:

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -59,7 +59,7 @@ TokenBase* exec_operation(const packToken& left, const packToken& right,
     if (match_op_id(data->opID, operation.getMask())) {
       try {
         return operation.exec(left, right, data).release();
-      } catch (const Operation::Reject& e) {
+      } catch (const Operation::Reject&) {
         continue;
       }
     }
@@ -329,7 +329,7 @@ TokenQueue_t calculator::toRPN(const char* expr,
       // add the parsed number to the output queue.
       std::string key = rpnBuilder::parseVar(expr, &expr);
 
-      if ((parser=config.parserMap.find(key))) {
+      if (NULL != (parser = config.parserMap.find(key))) {
         // Parse reserved words:
         try {
           parser(expr, &expr, &data);
@@ -467,7 +467,7 @@ TokenQueue_t calculator::toRPN(const char* expr,
             }
           } else if (data.opp.exists(op)) {
             data.handle_op(op);
-          } else if ((parser=config.parserMap.find(op[0]))) {
+          } else if (NULL != (parser=config.parserMap.find(op[0]))) {
             expr = start+1;
             try {
               parser(expr, &expr, &data);

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -10,6 +10,7 @@
 #include <stack>
 #include <utility>  // For std::pair
 #include <cstring>  // For strchr()
+#include <cstdlib>  // For strtoll()
 
 using cparse::calculator;
 using cparse::packToken;
@@ -490,7 +491,7 @@ TokenQueue_t calculator::toRPN(const char* expr,
   // Check for syntax errors (excess of operators i.e. 10 + + -1):
   if (data.lastTokenWasUnary) {
     rpnBuilder::cleanRPN(&data.rpn);
-    throw syntax_error("Expected operand after unary operator `" + data.opStack.top() + "`");
+    throw syntax_error("Expected operand after unary operator `" + normalize_op(data.opStack.top()) + "`");
   }
 
   std::string cur_op;

--- a/shunting-yard.cpp
+++ b/shunting-yard.cpp
@@ -10,7 +10,6 @@
 #include <stack>
 #include <utility>  // For std::pair
 #include <cstring>  // For strchr()
-#include <cstdlib>  // For strtoll()
 
 using cparse::calculator;
 using cparse::packToken;
@@ -694,7 +693,7 @@ packToken calculator::eval(TokenMap vars, bool keep_refs) const {
 
 std::unordered_set<std::string> calculator::get_variables() const {
   std::unordered_set<std::string> vars;
-  for (const auto& i: RPN) {
+  for (const auto& i : RPN) {
     if (i->type == tokType::VAR) {
       vars.insert(static_cast<Token<std::string>*>(i)->val);
     }

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -93,7 +93,7 @@ class packToken;
 
 // Adapt to std::queue<TokenBase*>
 class TokenQueue_t: public std::deque<TokenBase*> {
-public:
+ public:
   void push(TokenBase* t) {
     push_back(t);
   }

--- a/shunting-yard.h
+++ b/shunting-yard.h
@@ -237,7 +237,7 @@ struct rpnBuilder {
 };
 
 class RefToken;
-class opMap_t;
+struct opMap_t;
 struct evaluationData {
   TokenQueue_t rpn;
   TokenMap scope;
@@ -265,12 +265,12 @@ struct parserMap_t {
   rCharMap_t cmap;
 
   // Add reserved word:
-  void add(const std::string& word, const rWordParser_t* parser) {
+  void add(const std::string& word, rWordParser_t* parser) {
     wmap[word] = parser;
   }
 
   // Add reserved character:
-  void add(char c, const rWordParser_t* parser) {
+  void add(char c, rWordParser_t* parser) {
     cmap[c] = parser;
   }
 

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -4,6 +4,7 @@
 #include "catch.hpp"
 
 #include "./shunting-yard.h"
+#include "./shunting-yard-exceptions.h"
 
 using cparse::calculator;
 using cparse::packToken;
@@ -1181,4 +1182,9 @@ TEST_CASE("Get variables") {
   calculator c("a + sin(b) - c**2 / d");
   auto expectedVars = std::unordered_set<std::string>{"a", "b", "c", "d"};
   REQUIRE(c.get_variables() == expectedVars);
+}
+
+TEST_CASE("Unary operator error") {
+  calculator ecalc;
+  REQUIRE_THROWS_WITH(ecalc.compile("+"), "Expected operand after unary operator `+`");
 }

--- a/test-shunting-yard.cpp
+++ b/test-shunting-yard.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include "catch.hpp"
+#include "./catch.hpp"
 
 #include "./shunting-yard.h"
 #include "./shunting-yard-exceptions.h"


### PR DESCRIPTION
At high warning levels, MSVC complains about signed/unsigned comparisons, and conversions from 64 to 32 bit integers. Using the size_t and ptrdiff_t datatypes makes those warnings go away.
Also adding a few explicit casts for conversions between float and integer values where flagged as dangerous by the compiler.
