### PR TITLE
fix segment fault when multi-threading

### DIFF
--- a/builtin-features/functions.inc
+++ b/builtin-features/functions.inc
@@ -210,7 +210,12 @@ std::string packToken_str(const TokenBase* base, uint32_t nest) {
   if (base->type == MAP) {
     typeFuncs = static_cast<const TokenMap*>(base);
   } else {
-    typeFuncs = &calculator::type_attribute_map()[base->type];
+    cparse::typeMap_t::iterator it = calculator::type_attribute_map().find(base->type);
+    if (it != calculator::type_attribute_map().end()) {
+      typeFuncs = &(it->second);
+    } else {
+      return "";
+    }
   }
 
   // Check if this type has a custom stringify function:

--- a/builtin-features/operations.inc
+++ b/builtin-features/operations.inc
@@ -102,6 +102,9 @@ packToken MapIndex(const packToken& p_left, const packToken& p_right, evaluation
 // Resolve build-in operations for non-map types, e.g.: 'str'.len()
 packToken TypeSpecificFunction(const packToken& p_left, const packToken& p_right, evaluationData* data) {
   if (p_left->type == MAP) throw Operation::Reject();
+  if (calculator::type_attribute_map().find(p_left->type) == calculator::type_attribute_map().end()) {
+    throw undefined_operation(data->op, p_left, p_right);
+  }
 
   TokenMap& attr_map = calculator::type_attribute_map()[p_left->type];
   std::string& key = p_right.asString();


### PR DESCRIPTION
map operator [] will insert value if not find, which may cause segmentation fault in the case of multi-threading.